### PR TITLE
Fix MySQL port variable name

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -28,6 +28,6 @@ services:
       MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD} # 環境変数から参照
       TZ: "Asia/Tokyo"
     ports:
-      - "${MYSQL_POOT}:3306" # 環境変数から参照
+      - "${MYSQL_PORT}:3306" # 環境変数から参照
 volumes:
   db-data:


### PR DESCRIPTION
## Summary
- correct `MYSQL_PORT` variable name in compose.yml

## Testing
- `bundle exec rails test` *(fails: command not found: rails)*

------
https://chatgpt.com/codex/tasks/task_e_684a253d9464832fa6ccacabbea3850e