### PR TITLE
Fix entrypoint pid path

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,7 +2,7 @@
 set -e
 
 # Remove a potentially pre-existing server.pid for Rails.
-rm -f /myapp/tmp/pids/server.pid
+rm -f /app/tmp/pids/server.pid
 
 # Then exec the container's main process (what's set as CMD in the Dockerfile).
 exec "$@"


### PR DESCRIPTION
## Summary
- update `entrypoint.sh` to use `/app/tmp/pids/server.pid`

## Testing
- `ls -l entrypoint.sh`

------
https://chatgpt.com/codex/tasks/task_e_685e238951fc832f8439d9ebb5a49fd6